### PR TITLE
Put server_names_hash_bucket_size into global nginx.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This is an [Ansible](https://docs.ansible.com/ansible/latest/index.html) role th
 - `jitsi_nat`: Whether you're running _jitsi meet_ behind a NAT. Defaults to `false`. If enabled, you must set `jitsi_nat_local_ip` and `jitsi_nat_public_ip`.
 - `jitsi_nat_public_ip`: The public IP of your _jitsi meet_ host. Defaults to the IPv4 reported by [ipify](https://www.ipify.org/).
 - `jitsi_nat_private_ip`: The private IP of your _jitsi meet_ host. Defaults to the IPv4 that Ansible considers to be the default for the host.
-- `nginx_server_names_hash_bucket_size`: The `server_names_hash_bucket_size` of nginx. Will be declared in the global `nginx.conf`. Defaults to `64`.
+- `nginx_server_names_hash_bucket_size`: The `server_names_hash_bucket_size` of nginx. Will be declared in the global `nginx.conf` if `nginx_modify_server_names_hash_bucket_size` is set to `true`. Defaults to `64`.
+- `nginx_modify_server_names_hash_bucket_size`: Whether to change the value of `server_names_hash_bucket_size` in the global `nginx.conf` file. Defaults to `true`.
 
 Also look at [geerlingguy/ansible-role-certbot/.../defaults/main.yml](https://github.com/geerlingguy/ansible-role-certbot/blob/master/defaults/main.yml) for further configuration settings that are related to _certbot_.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is an [Ansible](https://docs.ansible.com/ansible/latest/index.html) role th
 - `jitsi_nat`: Whether you're running _jitsi meet_ behind a NAT. Defaults to `false`. If enabled, you must set `jitsi_nat_local_ip` and `jitsi_nat_public_ip`.
 - `jitsi_nat_public_ip`: The public IP of your _jitsi meet_ host. Defaults to the IPv4 reported by [ipify](https://www.ipify.org/).
 - `jitsi_nat_private_ip`: The private IP of your _jitsi meet_ host. Defaults to the IPv4 that Ansible considers to be the default for the host.
+- `nginx_server_names_hash_bucket_size`: The `server_names_hash_bucket_size` of nginx. Will be declared in the global `nginx.conf`. Defaults to `64`.
 
 Also look at [geerlingguy/ansible-role-certbot/.../defaults/main.yml](https://github.com/geerlingguy/ansible-role-certbot/blob/master/defaults/main.yml) for further configuration settings that are related to _certbot_.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,5 @@ jitsi_domain: "{{ inventory_hostname }}"
 jitsi_tcp_harvester_port: 4443
 jitsi_nat: false
 
+nginx_modify_server_names_hash_bucket_size: true
 nginx_server_names_hash_bucket_size: 64

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,5 @@ certbot_enabled: false
 jitsi_domain: "{{ inventory_hostname }}"
 jitsi_tcp_harvester_port: 4443
 jitsi_nat: false
+
+nginx_server_names_hash_bucket_size: 64

--- a/tasks/certbot/debian.yml
+++ b/tasks/certbot/debian.yml
@@ -4,3 +4,12 @@
     dest: /etc/nginx/sites-available/{{ jitsi_domain }}.conf
   notify:
     - restart_nginx
+- name: Ensure server_names_hash_bucket_size 64
+  lineinfile:
+    line: \1server_names_hash_bucket_size 64;
+    regexp: (\s*)#?\s*server_names_hash_bucket_size \d+;
+    path: /etc/nginx/nginx.conf
+    validate: nginx -t -c %s
+    backrefs: yes
+  notify:
+    - restart_nginx

--- a/tasks/certbot/debian.yml
+++ b/tasks/certbot/debian.yml
@@ -4,7 +4,8 @@
     dest: /etc/nginx/sites-available/{{ jitsi_domain }}.conf
   notify:
     - restart_nginx
-- name: Ensure server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }}
+- when: nginx_modify_server_names_hash_bucket_size|bool
+  name: Ensure server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }}
   lineinfile:
     line: \1server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }};
     regexp: (\s*)#?\s*server_names_hash_bucket_size \d+;

--- a/tasks/certbot/debian.yml
+++ b/tasks/certbot/debian.yml
@@ -4,9 +4,9 @@
     dest: /etc/nginx/sites-available/{{ jitsi_domain }}.conf
   notify:
     - restart_nginx
-- name: Ensure server_names_hash_bucket_size 64
+- name: Ensure server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }}
   lineinfile:
-    line: \1server_names_hash_bucket_size 64;
+    line: \1server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }};
     regexp: (\s*)#?\s*server_names_hash_bucket_size \d+;
     path: /etc/nginx/nginx.conf
     validate: nginx -t -c %s

--- a/tasks/jitsi/debian.yml
+++ b/tasks/jitsi/debian.yml
@@ -39,7 +39,9 @@
   template:
     src: sip-communicator.properties.j2
     dest: /etc/jitsi/videobridge/sip-communicator.properties
-- name: Restart jitsi-videobridge
+  register: jitsi_videobridge_sip_communicator
+- when: jitsi_videobridge_sip_communicator.changed
+  name: Restart jitsi-videobridge
   service:
     name: jitsi-videobridge
     state: restarted

--- a/templates/nginx-vhost.conf.j2
+++ b/templates/nginx-vhost.conf.j2
@@ -1,7 +1,5 @@
 # {{ ansible_managed }}
 
-server_names_hash_bucket_size 64;
-
 server {
     listen 80;
     listen [::]:80;


### PR DESCRIPTION
This changes the location of the `server_names_hash_bucket_size` directive.

Instead of it being added to the virtual host file, the global nginx.conf is patched.

Fixes #2