### PR TITLE
Feature/all config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,46 @@ ansible-playbook -i jitsi.ini jitsi.yml
 ansible-playbook -K -i jitsi.ini jitsi.yml
 ```
 
+## Configuration
+
+Jitsi-meet can be configured from this ansible-role. To do so, the
+`config.js` from upstream will be replaced by a file managed by this
+role.
+
+Enable this behaviour with the setting: `use_custom_jitsi_config_vars:
+yes`. 
+
+Then, set all required config variables. The defaults can be found in
+file `defaults/main.yml` of the role. All variables must be provided,
+not just those that you want to override! Pay attention to empty
+variables such as `analytics: {}`: due to the way Jitsi works, this has
+to be an empty object, and cannot be null.
+
+All settings, their values, usage and effect are documented
+in [jitsi-meet config.js](https://github.com/jitsi/jitsi-meet/blob/stable/jitsi-meet_4101/config.js).
+
+An incomplete example is:
+```
+jitsi_config:
+  hosts:
+    domain: "{{ jitsi_domain }}"
+    muc: "conference.{{ jitsi_domain }}"
+  bosh: "//{{ jitsi_domain }}/http-bind"
+  clientNode: "http://jitsi.org/jitsimeet"
+  testing:
+    enableFirefoxMulticast: true # Defaults to false
+```
+
+NOTE: the requirements of config.js may change at any moment when
+updating jitsi-meet, upstream is not very comunnicatative about this.
+Check with any CHANGELOG, and announcements about new required values
+before you update.
+
+NOTE: the structure is case-sensitive and follows the exact variable
+settings in config.js. So `webrctIceUdpDisable` is *not* the same as
+`WebRTCIceUDPDisable`. Jitsi is inconsistent in its naming of variables
+(e.g. It mixes `URL` and `Url` at random), so pay attention to the exact name.
+
 ## Uninstall
 
 The following commands help you to remove the installation.

--- a/README.md
+++ b/README.md
@@ -133,15 +133,13 @@ jitsi_config:
 ```
 
 NOTE:
-The requirements of `config.js` may change at any moment when
-updating jitsi-meet, upstream is not very comunnicatative about this.
-Check with any CHANGELOG and announcements of the _Jitsi Meet_ project about newly required values
-before you update.
+The requirements of `config.js` may change at any moment when updating jitsi-meet, upstream is not very comunnicatative about this.
+Check with any CHANGELOG and announcements of the _Jitsi Meet_ project about newly required values before you update.
 
-NOTE: the structure is case-sensitive and follows the exact variable
-settings in config.js. So `webrctIceUdpDisable` is *not* the same as
-`WebRTCIceUDPDisable`. Jitsi is inconsistent in its naming of variables
-(e.g. It mixes `URL` and `Url` at random), so pay attention to the exact name.
+NOTE:
+The structure is case-sensitive and follows the exact variable settings in config.js.
+So `webrctIceUdpDisable` is *not* the same as `WebRTCIceUDPDisable`.
+Jitsi is inconsistent in its naming of variables (e.g. It mixes `URL` and `Url` at random), so pay attention to the exact name.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ The requirements of `config.js` may change at any moment when updating jitsi-mee
 Check with any CHANGELOG and announcements of the _Jitsi Meet_ project about newly required values before you update.
 
 NOTE:
-The structure is case-sensitive and follows the exact variable settings in config.js.
-So `webrctIceUdpDisable` is *not* the same as `WebRTCIceUDPDisable`.
+The structure is case-sensitive and follows the exact variable settings in `config.js`.
+So, for example, `webrctIceUdpDisable` is very different to `WebRTCIceUDPDisable`.
 Jitsi is inconsistent in its naming of variables (e.g. it mixes `URL` and `Url` at random), so pay attention to the exact name.
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -108,8 +108,22 @@ _Jitsi Meet_ can be configured from this Ansible role. To do so, the
 file `/etc/jitsi/meet/{{ jitsi_domain }}-config.js` from the upstream package will be replaced by a file managed by this
 role.
 
-Enable this behaviour with the setting: `use_custom_jitsi_config_vars:
-yes`. 
+To enable this behaviour, define the variable: `use_custom_jitsi_config_vars` and set it to `yes`.
+
+I.e. add the last line of the following example to your `jitsi.ini`:
+
+```ini
+# jitsi.ini
+[jitsi]
+my-jitsi-server.com jitsi_domain=my-jitsi-server.com certbot_admin_email=admin@my-jitsi-server.com
+[jitsi:vars]
+ansible_user=ubuntu
+ansible_become=yes
+apt_mirror=http://archive.ubuntu.com/ubuntu # change to the mirror you already use
+certbot_enabled=yes
+jitsi_nat=no
+use_custom_jitsi_config_vars=yes  # manage your jitsi config through this role
+```
 
 Then, set all required config variables. The defaults can be found in
 file `defaults/main.yml` of the role. All variables must be provided,
@@ -139,7 +153,7 @@ Check with any CHANGELOG and announcements of the _Jitsi Meet_ project about new
 NOTE:
 The structure is case-sensitive and follows the exact variable settings in config.js.
 So `webrctIceUdpDisable` is *not* the same as `WebRTCIceUDPDisable`.
-Jitsi is inconsistent in its naming of variables (e.g. It mixes `URL` and `Url` at random), so pay attention to the exact name.
+Jitsi is inconsistent in its naming of variables (e.g. it mixes `URL` and `Url` at random), so pay attention to the exact name.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ _Jitsi Meet_ can be configured from this Ansible role. To do so, the
 file `/etc/jitsi/meet/{{ jitsi_domain }}-config.js` from the upstream package will be replaced by a file managed by this
 role.
 
-To enable this behaviour, define the variable: `use_custom_jitsi_config_vars` and set it to `yes`.
+To enable this behaviour, define the variable: `managed_jitsi_config` and set it to `yes`.
 
 I.e. add the last line of the following example to your `jitsi.ini`:
 
@@ -122,7 +122,7 @@ ansible_become=yes
 apt_mirror=http://archive.ubuntu.com/ubuntu # change to the mirror you already use
 certbot_enabled=yes
 jitsi_nat=no
-use_custom_jitsi_config_vars=yes  # manage your jitsi config through this role
+managed_jitsi_config=yes  # manage your jitsi config through this role
 ```
 
 Then, set all required config variables. The defaults can be found in

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ jitsi_config:
     enableFirefoxMulticast: true # Defaults to false
 ```
 
-NOTE: the requirements of config.js may change at any moment when
+NOTE:
+The requirements of `config.js` may change at any moment when
 updating jitsi-meet, upstream is not very comunnicatative about this.
 Check with any CHANGELOG, and announcements about new required values
 before you update.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ jitsi_config:
 NOTE:
 The requirements of `config.js` may change at any moment when
 updating jitsi-meet, upstream is not very comunnicatative about this.
-Check with any CHANGELOG, and announcements about new required values
+Check with any CHANGELOG and announcements of the _Jitsi Meet_ project about newly required values
 before you update.
 
 NOTE: the structure is case-sensitive and follows the exact variable

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ ansible-playbook -K -i jitsi.ini jitsi.yml
 
 ## Configuration
 
-Jitsi-meet can be configured from this ansible-role. To do so, the
+_Jitsi Meet_ can be configured from this Ansible role. To do so, the
 `config.js` from upstream will be replaced by a file managed by this
 role.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ ansible-playbook -K -i jitsi.ini jitsi.yml
 ## Configuration
 
 _Jitsi Meet_ can be configured from this Ansible role. To do so, the
-`config.js` from upstream will be replaced by a file managed by this
+file `/etc/jitsi/meet/{{ jitsi_domain }}-config.js` from the upstream package will be replaced by a file managed by this
 role.
 
 Enable this behaviour with the setting: `use_custom_jitsi_config_vars:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ All settings, their values, usage and effect are documented
 in [jitsi-meet config.js](https://github.com/jitsi/jitsi-meet/blob/stable/jitsi-meet_4101/config.js).
 
 An incomplete example is:
-```
+```yaml
 jitsi_config:
   hosts:
     domain: "{{ jitsi_domain }}"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ to be an empty object, and cannot be null.
 All settings, their values, usage and effect are documented
 in [jitsi-meet config.js](https://github.com/jitsi/jitsi-meet/blob/stable/jitsi-meet_4101/config.js).
 
-An incomplete example is:
+An most minimal example is:
 ```yaml
 jitsi_config:
   hosts:
@@ -143,7 +143,26 @@ jitsi_config:
   bosh: "//{{ jitsi_domain }}/http-bind"
   clientNode: "http://jitsi.org/jitsimeet"
   testing:
-    enableFirefoxMulticast: true # Defaults to false
+    enableFirefoxMulticast: false
+    p2pTestMode: false
+  desktopSharingChromeExtId: null
+  desktopSharingChromeSources: [ 'screen', 'window', 'tab' ]
+  desktopSharingChromeMinExtVersion: '0.1'
+  channelLastN: -1
+  enableWelcomePage: true
+  enableUserRolesBasedOnToken: false
+  p2p:
+    enabled: true
+    stunServers:
+      - urls: 'stun:stun.l.google.com:19302'
+      - urls: 'stun:stun1.l.google.com:19302'
+      - urls: 'stun:stun2.l.google.com:19302'
+    preferH264: true
+  analytics: {}
+  deploymentInfo: {}
+  localRecording: {}
+  e2eping: {}
+  deploymentUrls: {}
 ```
 
 NOTE:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ nginx_server_names_hash_bucket_size: 64
 
 # When true, this role will manage the `config.json` file and use the
 # variables as provided below under `jitsi_config`.
-use_custom_jitsi_config_vars: false
+managed_jitsi_config: false
 
 # Refer to the online config file for documentation on how to set
 # the variables, what they can contain and what they do.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ jitsi_nat: false
 nginx_modify_server_names_hash_bucket_size: true
 nginx_server_names_hash_bucket_size: 64
 
+# When true, this role will manage the `config.json` file and use the
+# variables as provided below under `jitsi_config`.
+use_custom_jitsi_config_vars: false
+
 # Refer to the online config file for documentation on how to set
 # the variables, what they can contain and what they do.
 # https://github.com/jitsi/jitsi-meet/blob/stable/jitsi-meet_4101/config.js

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,126 @@ jitsi_nat: false
 
 nginx_modify_server_names_hash_bucket_size: true
 nginx_server_names_hash_bucket_size: 64
+
+jitsi_config:
+  hosts:
+    domain: "{{ jitsi_domain }}"
+    muc: "conference.{{ jitsi_domain }}"
+    # anonymousdomain: guest.example.com
+    # authdomain: {{ jitsi_domain }}
+    # jirecon: jirecon.{{ jitsi_domain }}
+    # call_control: callcontrol.{{ jitsi_domain}}
+    # focus: focus.{{ jitsi_domain }}
+  bosh: "//{{ jitsi_domain }}/http-bind"
+  clientNode: "http://jitsi.org/jitsimeet"
+
+  testing:
+    enableFirefoxMulticast: false
+    p2pTestMode: false
+    # testMode: false
+    # noAutoPlayVideo: false
+  # webrtcIceUdpDisable: false
+  # webrtcIceTcpDisable: false
+  # disableAudioLevels: false
+  # startAudioOnly: false
+  # startAudioMuted: 10
+  # startWithAudioMuted: false
+  # startSilent: false
+  # resolution: 720
+  # constraints:
+    # video:
+      # aspectRatio: 16 / 9
+        # height:
+          # ideal: 720
+          # max: 720
+          # min: 240
+  # disableSimulcast: false
+  # enableLayerSuspension: false
+  # startVideoMuted: 10
+  # startWithVideoMuted: false
+  # preferH264: true
+  # disableH264: false
+  desktopSharingChromeExtId: null
+  desktopSharingChromeSources: [ 'screen', 'window', 'tab' ]
+  desktopSharingChromeMinExtVersion: '0.1'
+  # desktopSharingChromeDisabled: false
+  # desktopSharingFirefoxDisabled: false
+  # desktopSharingFrameRate:
+    # min: 5
+    # max: 5
+  # startScreenSharing: false
+
+  # fileRecordingsEnabled: false
+  # dropbox:
+    # appKey: "<APP_KEY>"
+    # redirectURI: "https://{{ jitsi_domain }}/subfolder/static/oauth.html"
+  # fileRecordingsServiceEnabled: false
+  # fileRecordingsServiceSharingEnabled: false
+
+  # liveStreamingEnabled: false
+  # transcribingEnabled: false
+  # autoCaptionOnRecord: false
+
+  channelLastN: -1
+  # disableRtx: false
+  # enableTcc: true
+  # enableRemb: false
+  # minParticipants: 2
+  # useStunTurn: true
+  # useIPv6: true
+  # openBridgeChannel: true
+
+  # useNicks: false
+  # requireDisplayName: true
+  enableWelcomePage: true
+  # enableClosePage: false
+  # disable1On1Mode: false
+  # defaultLanguage: 'en'
+  enableUserRolesBasedOnToken: false
+  # enableFeaturesBasedOnToken: false
+  # lockRoomGuestEnabled: false
+  # roomPasswordNumberOfDigits: 10
+  # default: roomPasswordNumberOfDigits: false
+  # noticeMessage: ''
+  # enableCalendarIntegration: false
+
+  # gatherStats: false
+  # callStatsId: ''
+  # callStatsSecret: ''
+  # enableDisplayNameInStats: false
+  # enableEmailInStats: false
+
+  # disableThirdPartyRequests: false
+  p2p:
+    enabled: true
+    # useStunTurn: true
+    stunServers:
+      - urls: 'stun:stun.l.google.com:19302'
+      - urls: 'stun:stun1.l.google.com:19302'
+      - urls: 'stun:stun2.l.google.com:19302'
+    # iceTransportPolicy: 'all'
+    preferH264: true
+    # disableH264: false
+    # backToP2PDelay: 5
+  analytics: {}
+    # googleAnalyticsTrackingId: 'your-tracking-id-UA-123456-1'
+    # amplitudeAPPKey: '<APP_KEY>'
+    # scriptURLs:
+    #   - "libs/analytics-ga.min.js"
+    #   - "https://example.com/my-custom-analytics.js"
+  deploymentInfo: {}
+    # shard: "shard1"
+    # region: "europe"
+    # userRegion: "asia"
+  localRecording: {}
+    # enabled: true
+    # format: 'flac'
+  e2eping: {}
+    # pingInterval: 10000
+    # analyticsInterval: 60000
+  # DesktopSharingSourceDevice: 'sample-id-or-label'
+  # disableDeepLinking: false
+  # disableLocalVideoFlip: false
+  deploymentUrls: {}
+    # userDocumentationURL: 'https:#docs.example.com/video-meetings.html'
+    # downloadAppsUrl: 'https:#docs.example.com/our-apps.html'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ jitsi_nat: false
 nginx_modify_server_names_hash_bucket_size: true
 nginx_server_names_hash_bucket_size: 64
 
+# Refer to the online config file for documentation on how to set
+# the variables, what they can contain and what they do.
+# https://github.com/jitsi/jitsi-meet/blob/stable/jitsi-meet_4101/config.js
 jitsi_config:
   hosts:
     domain: "{{ jitsi_domain }}"

--- a/tasks/jitsi/config.yml
+++ b/tasks/jitsi/config.yml
@@ -1,0 +1,6 @@
+- name: "Override jitsi config.js"
+  template:
+    src: config.js.j2
+    backup: yes
+    force: yes
+    dest: /etc/jitsi/meet/{{ jitsi_domain }}-config.js

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   name: Install Jitsi
   import_tasks: jitsi/debian.yml
 
-- when: use_custom_jitsi_config_vars|bool
+- when: managed_jitsi_config|bool
   name: Configure Jitsi
   import_tasks: jitsi/config.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,8 @@
   name: Install Jitsi
   import_tasks: jitsi/debian.yml
 
-- name: Configure Jitsi
+- when: use_custom_jitsi_config_vars|bool
+  name: Configure Jitsi
   import_tasks: jitsi/config.yml
 
 - when: (certbot_enabled|bool) and (ansible_os_family|lower == 'debian')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,9 @@
   name: Install Jitsi
   import_tasks: jitsi/debian.yml
 
+- name: Configure Jitsi
+  import_tasks: jitsi/config.yml
+
 - when: (certbot_enabled|bool) and (ansible_os_family|lower == 'debian')
   name: Update nginx configuration for Certbot
   import_tasks: certbot/debian.yml

--- a/templates/config.js.j2
+++ b/templates/config.js.j2
@@ -1,0 +1,2 @@
+/* {{ ansible_managed }} */
+var config = {{ jitsi_config | to_nice_json }};


### PR DESCRIPTION
This allows all jitisi-meet-config variables to be set from within this role.

I probably removes the need to install jitisi-meet-config deb package; and removes the need to run debconf on that, but since we move the file generated there, into a backup, we do create a nice reference. 

Please let me know if you wish me to remove debconf setup and the installation of that package.